### PR TITLE
fixes: #29 - feat: treat unmatched versions as error condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,16 +5,15 @@ const semver = require('semver')
 class RouteVersionUnmatchedError extends Error {
   constructor (message) {
     super(message)
-    this.constructor = RouteVersionUnmatchedError
-
-    const actualProto = new.target.prototype
-    Object.setPrototypeOf(this, actualProto)
-    this.message = message
-    this.name = 'RouteVersionUnmatchedError'
+    this.name = this.constructor.name
   }
 }
 
 class versionRouter {
+  static get RouteVersionUnmatchedError () {
+    return RouteVersionUnmatchedError
+  }
+
   static route (versionsMap = new Map(), options = new Map()) {
     return (req, res, next) => {
       for (let [versionKey, versionRouter] of versionsMap) {
@@ -41,7 +40,4 @@ class versionRouter {
   }
 }
 
-module.exports = {
-  versionRouter,
-  RouteVersionUnmatchedError
-}
+module.exports = versionRouter

--- a/index.js
+++ b/index.js
@@ -2,6 +2,18 @@
 
 const semver = require('semver')
 
+class RouteVersionUnmatchedError extends Error {
+  constructor (message) {
+    super(message)
+    this.constructor = RouteVersionUnmatchedError
+
+    const actualProto = new.target.prototype
+    Object.setPrototypeOf(this, actualProto)
+    this.message = message
+    this.name = 'RouteVersionUnmatchedError'
+  }
+}
+
 class versionRouter {
   static route (versionsMap = new Map(), options = new Map()) {
     return (req, res, next) => {
@@ -16,7 +28,7 @@ class versionRouter {
         return defaultRoute(req, res, next)
       }
 
-      return next()
+      return next(new RouteVersionUnmatchedError(`${req.version} doesn't match any versions`))
     }
   }
 
@@ -29,4 +41,7 @@ class versionRouter {
   }
 }
 
-module.exports = versionRouter
+module.exports = {
+  versionRouter,
+  RouteVersionUnmatchedError
+}

--- a/test/sanity.test.js
+++ b/test/sanity.test.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const test = require('ava')
-const versionRouterExports = require('../index')
-const versionRouter = versionRouterExports.versionRouter
+const versionRouter = require('../index')
 
 test('given a versioned router, match the route', t => {
   const v1 = '1.0'
@@ -65,7 +64,7 @@ test('given a versioned router, dont match the requestVersion and error out if n
   const result = middleware(req, resIn, nextHandler)
   t.falsy(resIn)
   t.truthy(result instanceof Error)
-  t.truthy(result instanceof versionRouterExports.RouteVersionUnmatchedError)
+  t.truthy(result instanceof versionRouter.RouteVersionUnmatchedError)
   t.truthy(result.name === 'RouteVersionUnmatchedError')
   t.truthy(result.message === `${requestedVersion} doesn't match any versions`)
 })


### PR DESCRIPTION
also add one test to ensure first match wins

NB before you merge: This branch breaks backwards compatibility so the error class can be exported.  Feel free to let me know if you'd prefer to prioritize backward compatibility and keep the exports the same.

I'd personally prefer to have the error type exported so we don't have to rely on the name, but if you'd like me to reroll this in a backward-compatible way I'd be happy to.

One last thing - sorry about the not-so-related test, but to me it's still in the spirit of this issue (API version updates being awesomely maintainable).

Thanks again!