### PR TITLE
fix: remove deprecated Snyk vulnerabilities badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Build](https://github.com/lirantal/express-version-route/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/lirantal/express-version-route/actions?query=workflow%3ACI)
 [![Codecov](https://img.shields.io/codecov/c/gh/lirantal/express-version-route.svg)](https://codecov.io/gh/lirantal/express-version-route)
 [![npm module downloads](http://img.shields.io/npm/dt/express-version-route.svg)](https://www.npmjs.org/package/express-version-route)
-[![Known Vulnerabilities](https://snyk.io/test/github/lirantal/express-version-route/badge.svg)](https://snyk.io/test/github/lirantal/express-version-route)
 [![Security Responsible Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md
 )
 


### PR DESCRIPTION
The Snyk vulnerabilities badge (`snyk.io/test/github/...`) has been deprecated and no longer renders correctly. Removing it from the README so the badge row stays clean.